### PR TITLE
Edit the command with prompt_toolkit instead of readline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,9 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License"
 ]
 dependencies = [
-    "llm"
+    "llm",
+    "prompt_toolkit>=3.0.43",
+    "pygments>=2.17.2",
 ]
 
 [project.urls]


### PR DESCRIPTION
The readline on some Python versions is based on libedit, which doesn't support either set_startup_hook or insert_text - it just sits there waiting for input. IPython uses prompt_toolkit for editing, which feels like a more modern solution. It can even highlight the shell command using Pygment's BashLexer.

Fixes #3 