### PR TITLE
fix: support --print-only flag (resolves #14)

### DIFF
--- a/llm_cmd.py
+++ b/llm_cmd.py
@@ -21,7 +21,8 @@ def register_commands(cli):
     @click.option("-m", "--model", default=None, help="Specify the model to use")
     @click.option("-s", "--system", help="Custom system prompt")
     @click.option("--key", help="API key to use")
-    def cmd(args, model, system, key):
+    @click.option("-p", "--print-only", is_flag=True, help="Print command instead of putting in interactive prompt")
+    def cmd(args, model, system, key, print_only):
         """Generate and execute commands in your shell"""
         from llm.cli import get_default_model
         prompt = " ".join(args)
@@ -30,7 +31,10 @@ def register_commands(cli):
         if model_obj.needs_key:
             model_obj.key = llm.get_key(key, model_obj.needs_key, model_obj.key_env_var)
         result = model_obj.prompt(prompt, system=system or SYSTEM_PROMPT)
-        interactive_exec(str(result))
+        if print_only:
+            print(str(result).strip())
+        else:
+            interactive_exec(str(result))
 
 def interactive_exec(command):
     session = PromptSession(lexer=PygmentsLexer(BashLexer))

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -1,6 +1,25 @@
 from llm.plugins import pm
+from click.testing import CliRunner
+from llm_cmd import register_commands
 
 
 def test_plugin_is_installed():
     names = [mod.__name__ for mod in pm.get_plugins()]
     assert "llm_cmd" in names
+
+def test_print_only_flag():
+    runner = CliRunner()
+    
+    result = runner.invoke(cmd, ["--print-only", "list files"])
+    assert result.exit_code == 0
+    # Should output just the command without any prefix
+    assert result.output.strip() == "ls"
+
+
+def test_no_print_flag():
+    runner = CliRunner()
+    
+    result = runner.invoke(cmd, ["list files"])
+    assert result.exit_code == 0
+    # Should not contain the command output directly
+    assert "ls" not in result.output

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -1,25 +1,16 @@
-from llm.plugins import pm
-from click.testing import CliRunner
-from llm_cmd import register_commands
+from llm.plugins import load_plugins, pm
+import click
 
 
 def test_plugin_is_installed():
+    load_plugins()
     names = [mod.__name__ for mod in pm.get_plugins()]
     assert "llm_cmd" in names
 
 def test_print_only_flag():
-    runner = CliRunner()
-    
-    result = runner.invoke(cmd, ["--print-only", "list files"])
-    assert result.exit_code == 0
-    # Should output just the command without any prefix
-    assert result.output.strip() == "ls"
+    load_plugins()
 
-
-def test_no_print_flag():
-    runner = CliRunner()
-    
-    result = runner.invoke(cmd, ["list files"])
-    assert result.exit_code == 0
-    # Should not contain the command output directly
-    assert "ls" not in result.output
+    cli = click.Group()
+    pm.hook.register_commands(cli=cli)
+    cmd = cli.commands['cmd']
+    assert any(opt.name == "print_only" for opt in cmd.params)


### PR DESCRIPTION
Fixes #14 and includes #18 as it hasn't been merged yet but I trust it will be.

Added a slightly silly unit test ensuring that the command was added. Did manual testing in this way:
```
llm cmd -p "list files in current directory"              
ls -l
```
And ensured that the behavior for the same command without the `-p` or `--print-only` flag is unchanged.

Thank you for creating `llm` and a whole modular ecosystem around it, @simonw!