### PR TITLE
strip ``` from llm outputs

### DIFF
--- a/llm_cmd.py
+++ b/llm_cmd.py
@@ -30,6 +30,7 @@ def register_commands(cli):
         if model_obj.needs_key:
             model_obj.key = llm.get_key(key, model_obj.needs_key, model_obj.key_env_var)
         result = model_obj.prompt(prompt, system=system or SYSTEM_PROMPT)
+        result = '\n'.join([i for i in str(result).splitlines() if not i.startswith('```')])
         interactive_exec(str(result))
 
 def interactive_exec(command):


### PR DESCRIPTION
some models (e.g. kimi, qwen) uses ```bash in output . we need to strip them before exec.